### PR TITLE
docs: update checkpoint tutorial flags

### DIFF
--- a/docs/source/tutorial/tutorial.rst
+++ b/docs/source/tutorial/tutorial.rst
@@ -660,7 +660,7 @@ stored in the ``checkpoints`` directory and they are saved at the fopllowing poi
   which holds the gridded visibilities and associated weights, variances, models, etc
 
 In the case that you wish to skip a step in the pipeline, you can use the
-``--calibrate-checkpoint`` or ``--grid-checkpoint`` options to skip the calibration
+``--calibrate-checkpoint`` or ``--gridding-checkpoint`` options to skip the calibration
 or gridding steps respectively.
 
 .. attention::
@@ -670,11 +670,12 @@ or gridding steps respectively.
 
 In the below example we will run ``pyfhd`` with the ``--calibrate-checkpoint``
 option, which will skip the calibration and visibility step and go straight to
-gridding.
+gridding. The checkpoint flag is a toggle; ``pyfhd`` will load the expected
+checkpoint file from the configured output checkpoint directory.
 
 .. code-block:: bash
 
-  pyfhd -c ./input/1088285600_example/1088285600_example.yaml --calibrate-checkpoint ./output/pyfhd_1088285600_example/checkpoints/1088285600_example_calibrate_checkpoint.h5 1088285600
+  pyfhd -c ./input/1088285600_example/1088285600_example.yaml --calibrate-checkpoint 1088285600
 
 Within the logs of the ``pyfhd`` you should see the following message::
 
@@ -1211,7 +1212,7 @@ We'll use the calibrate-checkpoint example earlier to run it
 
 .. code-block:: bash
 
-  pyfhd -c ./input/1088285600_example/1088285600_example.yaml --calibrate-checkpoint ./output/pyfhd_1088285600_example/checkpoints/1088285600_example_calibrate_checkpoint.h5 1088285600
+  pyfhd -c ./input/1088285600_example/1088285600_example.yaml --calibrate-checkpoint 1088285600
 
 This would be the same as runnning the command below:
 
@@ -1221,7 +1222,7 @@ This would be the same as runnning the command below:
     --input-path "./input/1088285600_example/" \
     --description "1088285600_gridding_example" \
     --saved-beam-file-path "./input/1088285600_example/gauss_beam_pointing0_167635008Hz.h5" \
-    --calibrate-checkpoint "./output/pyfhd_1088285600_example/checkpoints/1088285600_example_calibrate_checkpoint.h5" \
+    --calibrate-checkpoint \
     --recalculate-grid \
     --image-filter 'filter_uv_uniform' \
     --no-mask-mirror-indices \


### PR DESCRIPTION
## Summary

Fixes the checkpoint tutorial examples so they match the current CLI behavior described in #99.

## Changes

- Update the tutorial to use `--gridding-checkpoint`, matching the parser option name.
- Remove the stale checkpoint file path argument after `--calibrate-checkpoint`.
- Clarify that `--calibrate-checkpoint` is a toggle that loads the expected checkpoint from the configured output checkpoint directory.

## Verification

- `python3` text assertions for the tutorial checkpoint examples
- `grep` check for stale `--calibrate-checkpoint ./output`, quoted checkpoint path, and `--grid-checkpoint`
- `git diff --check`

Note: I also tried `make html`, but this local environment does not currently have `sphinx-build` installed, so the docs build could not be run here.

Closes #99.

## Types of Changes

- [x] Documentation

## Changelog

### Bug Fixes

- Fixed checkpoint tutorial commands to match the current `--calibrate-checkpoint` and `--gridding-checkpoint` CLI flags.

## Checklist

### General PR Checklist

- [x] I have the read the contribution guide
- [x] Add all the above to the Changelog into the unreleased section

### Documentation Checklist

- [ ] The documentation is able to build successfully with any new changes and they are visible in your own build

Docs build note: `make html` could not run locally because `sphinx-build` is not installed in this environment.
