### PR TITLE
Remove references to `beam_model_version` in pyfhd_config

### DIFF
--- a/src/pyfhd/beam_setup/antenna.py
+++ b/src/pyfhd/beam_setup/antenna.py
@@ -105,7 +105,6 @@ def init_beam(obs: dict, pyfhd_config: dict, logger: Logger) -> dict:
         "antenna_type": pyfhd_config["instrument"],
         "size_meters": ant_size_m,
         "names": ant_names,
-        "beam_model_version": pyfhd_config["beam_model_version"],
         "freq": freq_center,
         "nfreq_bin": nfreq_bin,
         "n_ant_elements": n_dipoles,

--- a/tests/test_beam/test_beam_power.py
+++ b/tests/test_beam/test_beam_power.py
@@ -46,7 +46,6 @@ def test_beam_power():
 
     pyfhd_config = {
         "instrument": "mwa",
-        "beam_model_version": "aee",
         "psf_dim": 14,
         "psf_resolution": 10,
         "beam_mask_threshold": 1e2,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `beam_model_version` option was removed from the config in #113 but a few references were missed, which cause errors. This just removes those references.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of Changes
- [x] Bug Fixes
- [ ] New Feature(s) or Translations
- [ ] New tests
- [ ] Breaking Changes
- [ ] Refactoring/Internal restructuring
- [ ] Documentation
- [ ] Version Change
- [ ] Build or CI Change
- [ ] Other

## Checklist
<!--- Please remove any checklists that don't apply to your change type(s)-->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
**Bug Fixes**
- [ ] I have linked all issues associated with the bugs above.
- [x] I have added new tests or adjusted existing tests to cover bug (check the
Existing Tests Checklist above)
- [ ] I have updated the [Changelog](https://pyfhd.readthedocs.io/en/latest/changelog/changelog.html)
      with details on the bug fix in the unreleased section (should be at the top
      of the relevant section -- changes are in reverse chronological order).