### PR TITLE
Be consistent about conserve memory option names

### DIFF
--- a/src/pyfhd/calibration/calibrate.py
+++ b/src/pyfhd/calibration/calibrate.py
@@ -138,8 +138,6 @@ def calibrate(
             logger=logger,
             fill_model_visibilities=True,
             model_delay_filter=pyfhd_config["calibration_model_delay_filter"],
-            conserve_memory=pyfhd_config["conserve_memory"],
-            mem_thresh=pyfhd_config["memory_threshold"],
         )
         degrid_end = time.time()
         _print_time_diff(degrid_start, degrid_end, "Model visibility creation", logger)

--- a/src/pyfhd/gridding/visibility_degrid.py
+++ b/src/pyfhd/gridding/visibility_degrid.py
@@ -37,8 +37,6 @@ def visibility_degrid(
     vis_input: NDArray[np.complex128] | None = None,
     spectral_model_uv_arr: NDArray[np.float64] | None = None,
     beam_per_baseline: bool = False,
-    conserve_memory: bool = False,
-    memory_threshold: float | int = 1e8,
 ):
     """
     Generate visibilities from a 2D hyperresolved {u,v} plane using the Fourier
@@ -82,8 +80,6 @@ def visibility_degrid(
     beam_per_baseline : bool, optional
         Generate beams with corrective phases given the baseline location, by
         default False
-    conserve_memory : bool, optional
-        Reduce memory load by running loops, by default False
 
     Returns
     -------
@@ -96,10 +92,10 @@ def visibility_degrid(
 
     n_spectral = obs["degrid_spectral_terms"]
     interp_flag = pyfhd_config["interpolate_kernel"]
-    if conserve_memory:
+    if pyfhd_config["conserve_memory"]:
         # memory threshold is in bytes
-        if memory_threshold < 1e6:
-            memory_threshold = 1e8
+        if pyfhd_config["memory_threshold"] < 1e6:
+            pyfhd_config["memory_threshold"] = 1e8
 
     # If both beam and interp_flag leave a warning, prioritise beam_per_baseline
     if beam_per_baseline and interp_flag:
@@ -213,12 +209,12 @@ def visibility_degrid(
         inds_full = ri[ri[bin_i[bi]] : ri[bin_i[bi] + 1]]
 
         # if constraining memory usage, then est number of loops needed
-        if conserve_memory:
+        if pyfhd_config["conserve_memory"]:
             required_bytes = 16 * vis_n_full * psf_dim3
-            mem_iter = int(np.ceil(required_bytes / memory_threshold))
+            mem_iter = int(np.ceil(required_bytes / pyfhd_config["memory_threshold"]))
             if mem_iter > 1:
                 vis_n_per_iter = int(np.ceil(vis_n_full / mem_iter))
-        if not conserve_memory or mem_iter == 1:
+        if not pyfhd_config["conserve_memory"] or mem_iter == 1:
             vis_n = vis_n_full.copy()
             inds = inds_full.copy()
             mem_iter = 1
@@ -361,7 +357,7 @@ def visibility_degrid(
 
         loop_time = time.time()
         if (
-            n_bin_use > 1
+            n_bin_use > int(1.0 / reporting_frac)
             and bi % int(np.round(n_bin_use * reporting_frac)) == 0
             and (bi + 1) < n_bin_use
         ):

--- a/src/pyfhd/pyfhd_tools/pyfhd_setup.py
+++ b/src/pyfhd/pyfhd_tools/pyfhd_setup.py
@@ -222,15 +222,18 @@ def pyfhd_parser():
         "--conserve-memory",
         default=False,
         action=OrderedBooleanOptionalAction,
-        help="Optionally split many loops into chunks in the case of high memory "
-        "usage.",
+        help="Optionally split processing into chunks in various places throughout "
+        "pyfhd (e.g. degridding, source DFTing and mapping function construction) "
+        "to limit memory usage. See `memory-threshold` for the threshold in bytes.",
     )
     parser.add_argument(
         "--memory-threshold",
         type=float,
         default=1e9,
         help="Set a memory threshold for each chunk in bytes. By default "
-        "it is set at ~1GB",
+        "it is set at ~1GB. Note that the full memory usage will be higher, "
+        "this limits additional memory usage in various places throughout pyfhd "
+        "including in degridding, source DFTing and mapping function construction.",
     )
     parser.add_argument(
         "--n-pol",

--- a/src/pyfhd/source_modeling/source_utils.py
+++ b/src/pyfhd/source_modeling/source_utils.py
@@ -835,7 +835,7 @@ def source_dft(
     yvals: FloatArray | None = None,
     inds_use: IntArray | None = None,
     conserve_memory: bool = True,
-    mem_thresh: float = 1e8,
+    memory_threshold: float = 1e8,
 ) -> ComplexArray:
     """
     DFT sources to a model uv plane.
@@ -865,7 +865,7 @@ def source_dft(
     conserve_memory : bool
         Option to limit memory use by chunking the number of sources to DFT
         at a time.
-    mem_thresh : float
+    memory_threshold : float
         Memory threshold, which sets the number of sources to DFT at once if
         conserve_memory is True. Default is 1e8.
 
@@ -900,12 +900,12 @@ def source_dft(
 
     n_calc = xvals.size * n_src
     mem_factor = 32.0  # from rough empirical estimations
-    if conserve_memory and (n_calc * mem_factor > mem_thresh):
+    if conserve_memory and (n_calc * mem_factor > memory_threshold):
         # DFT with memory management
         # If the max memory is less than the estimated memory needed to DFT all
         # sources at once, then break the DFT into chunks
         sources_per_bin = int(
-            np.round(n_src / np.ceil(n_calc * mem_factor / mem_thresh))
+            np.round(n_src / np.ceil(n_calc * mem_factor / memory_threshold))
         )
         sources_per_bin = max([sources_per_bin, 1])
         memory_bins = int(np.ceil(n_src / sources_per_bin))
@@ -941,7 +941,7 @@ def source_dft(
         )
         loop_time = time.time()
         if (
-            memory_bins > 1
+            memory_bins > int(1.0 / reporting_frac)
             and bin_i % int(np.round(memory_bins * reporting_frac)) == 0
             and (bin_i + 1) < memory_bins
         ):
@@ -968,7 +968,7 @@ def source_dft_multi(
     logger: logging.Logger,
     uv_i_use: tuple[IntArray] | None = None,
     conserve_memory: bool = True,
-    mem_thresh: float = 1e8,
+    memory_threshold: float = 1e8,
 ) -> ComplexArray:
     """
     DFT multiple sources to a model uv plane.
@@ -997,7 +997,7 @@ def source_dft_multi(
     conserve_memory : bool
         Option to limit memory use by chunking the number of sources to DFT
         at a time.
-    mem_thresh : float
+    memory_threshold : float
         Memory threshold, which sets the number of sources to DFT at once if
         conserve_memory is True. Default is 1e8.
 
@@ -1044,7 +1044,7 @@ def source_dft_multi(
         dimension=dimension,
         elements=elements,
         flux=flux_arr,
-        mem_thresh=mem_thresh,
+        memory_threshold=memory_threshold,
         conserve_memory=conserve_memory,
         logger=logger,
     )
@@ -1063,7 +1063,7 @@ def source_dft_model(
     uv_mask: BoolArray | None = None,
     sigma_threshold: float | None = None,
     conserve_memory: bool = True,
-    mem_thresh: float = 1e8,
+    memory_threshold: float = 1e8,
 ) -> ComplexArray:
     """
     Coordinate DFTing sources to a model uv plane.
@@ -1093,7 +1093,7 @@ def source_dft_model(
     conserve_memory : bool
         Option to limit memory use by chunking the number of sources to DFT
         at a time.
-    mem_thresh : float
+    memory_threshold : float
         Memory threshold, which sets the number of sources to DFT at once if
         conserve_memory is True. Default is 1e8.
 
@@ -1123,7 +1123,7 @@ def source_dft_model(
         logger=logger,
         uv_i_use=uv_i_use,
         conserve_memory=conserve_memory,
-        mem_thresh=mem_thresh,
+        memory_threshold=memory_threshold,
     )
 
     return model_uv_arr

--- a/src/pyfhd/source_modeling/vis_source_model.py
+++ b/src/pyfhd/source_modeling/vis_source_model.py
@@ -27,8 +27,6 @@ def vis_source_model(
     model_delay_filter: bool = True,
     fill_model_visibilities: bool = False,
     vis_model: BoolArray | None = None,
-    conserve_memory: bool = True,
-    mem_thresh: float = 1e8,
 ) -> ComplexArray:
     """
     Simulate model visibilities via degridding.
@@ -64,12 +62,6 @@ def vis_source_model(
         Create all model visibilities disregarding flags, by default False
     vis_model : ndarray of complex | None, optional
         Extra model visibilities to add to the degridded products, by default None.
-    conserve_memory : bool
-        Option to limit memory use by chunking the number of sources to DFT
-        at a time.
-    mem_thresh : float
-        Memory threshold, which sets the number of sources to DFT at once if
-        conserve_memory is True. Default is 1e8.
 
     Returns
     -------
@@ -139,8 +131,8 @@ def vis_source_model(
         # sigma_threshold=2.,
         uv_mask=uv_mask_use,
         logger=logger,
-        conserve_memory=conserve_memory,
-        mem_thresh=mem_thresh,
+        conserve_memory=pyfhd_config["conserve_memory"],
+        memory_threshold=pyfhd_config["memory_threshold"],
     )
     dft_end = time.time()
     _print_time_diff(dft_start, dft_end, "source DFT", logger)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,6 +108,8 @@ def mwa_aee_beam_zenith_2013(zenith_obs_2013_main, tmp_path_factory):
         "output_dir": tmp_path_factory.mktemp("zenith_2013"),
         "obs_id": 1061316296,
         "cal_stop": False,
+        "conserve_memory": True,
+        "memory_threshold": 1e10,
     }
 
     psf, antenna = create_psf(obs, pyfhd_config, logger=logging.getLogger())
@@ -164,7 +166,7 @@ def model_uv_zenith_2013():
         dimension=dim_use,
         elements=dim_use,
         flux=flux_arr,
-        mem_thresh=1e10,
+        memory_threshold=5e9,  # chosen to exercise parts of the code
         conserve_memory=True,
         logger=logging.getLogger(),
     )

--- a/tests/test_gridding/test_visibility_degrid.py
+++ b/tests/test_gridding/test_visibility_degrid.py
@@ -1,6 +1,7 @@
 from logging import Logger
 from os import environ as env
 from pathlib import Path
+import copy
 
 import pytest
 import numpy as np
@@ -76,13 +77,15 @@ def before_degridding(data_dir: Path, number: int, request: pytest.FixtureReques
     h5_save_dict["beam_per_baseline"] = beam_per_baseline
 
     if h5_save_dict["conserve_memory"] > 1e6:
-        h5_save_dict["memory_threshold"] = h5_save_dict["conserve_memory"]
-        h5_save_dict["conserve_memory"] = True
+        h5_save_dict["pyfhd_config"]["memory_threshold"] = h5_save_dict[
+            "conserve_memory"
+        ]
+        h5_save_dict["pyfhd_config"]["conserve_memory"] = True
     elif h5_save_dict["conserve_memory"] > 0:
-        h5_save_dict["memory_threshold"] = 1e8
-        h5_save_dict["conserve_memory"] = True
+        h5_save_dict["pyfhd_config"]["memory_threshold"] = 1e8
+        h5_save_dict["pyfhd_config"]["conserve_memory"] = True
     else:
-        h5_save_dict["conserve_memory"] = False
+        h5_save_dict["pyfhd_config"]["conserve_memory"] = False
 
     save(before_gridding, h5_save_dict, "before_file")
 
@@ -125,8 +128,6 @@ def test_visibility_degrid(
         vis_input=h5_before["vis_input"],
         spectral_model_uv_arr=h5_before["spectral_model_uv_arr"],
         beam_per_baseline=h5_before["beam_per_baseline"],
-        conserve_memory=h5_before["conserve_memory"],
-        memory_threshold=h5_before["memory_threshold"],
     )
 
     npt.assert_allclose(vis_return, vis_expected, atol=1e-15)
@@ -141,18 +142,19 @@ def test_vis_degrid_zenith_2013(
     _, psf, obs, pyfhd_config = mwa_aee_beam_zenith_2013
     params = zenith_params_2013
 
+    pyfhd_config_use = copy.deepcopy(pyfhd_config)
+    pyfhd_config_use["conserve_memory"] = True
+    pyfhd_config_use["memory_threshold"] = 1e10
     vis_model = visibility_degrid(
         image_uv=model_uv_full,
         vis_weights=None,
         obs=obs,
         psf=psf,
         params=params,
-        pyfhd_config=pyfhd_config,
+        pyfhd_config=pyfhd_config_use,
         logger=Logger(1),
         polarization=pol_i,
         fill_model_visibilities=True,
-        conserve_memory=True,
-        memory_threshold=1e10,
     )
 
     fhd_vis_model_file = fetch_data("2013_zenith_gleam_model_vis_2freq")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I was using different parameter names in some places. This also gets the settings from the `pyfhd_config` dict when possible rather than passing them around as parameters to functions.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of Changes
- [ ] Bug Fixes
- [ ] New Feature(s) or Translations
- [ ] New tests
- [ ] Breaking Changes
- [x] Refactoring/Internal restructuring
- [ ] Documentation
- [ ] Version Change
- [ ] Build or CI Change
- [ ] Other

## Checklist
<!--- Please remove any checklists that don't apply to your change type(s)-->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
**Refactoring/Internal restructuring**
- [x] I have added or updated the docstrings for any new or updated funtions
      using the numpydoc docstring format.
- [x] I am maintaining comparibility to FHD so other developers can tell where
      to find related functionality between pyfhd and FHD. If functions are
      structured or named differently from FHD, I have documented what the related
      FHD programs and/or functions are in docstrings.
- [x] Existing tests pass and do not run slower than on main.
