### PR TITLE
Fix a bug in degridding where some visibilities aren't formed

### DIFF
--- a/docs/source/changelog/changelog.md
+++ b/docs/source/changelog/changelog.md
@@ -38,6 +38,7 @@ the new `analytic-beam-yaml` option to configure them.
 * Added handling for `~` in paths in config yamls.
 
 ### Bug Fixes
+* Fixed a bug in degridding which lead to some visibilities not being calculated.
 * Fixed a couple of bugs in beam and psf setup where the FFT direction or
 normalization convention was wrong.
 * Fixed a couple small bugs in `plotting.image.quick_image` that caused the

--- a/src/pyfhd/gridding/visibility_degrid.py
+++ b/src/pyfhd/gridding/visibility_degrid.py
@@ -13,6 +13,7 @@ from .gridding_utils import (
     grid_beam_per_baseline,
 )
 from ..pyfhd_tools.pyfhd_utils import (
+    idl_argunique,
     l_m_n,
     rebin,
     weight_invert,
@@ -274,7 +275,7 @@ def visibility_degrid(
                 ) * group_max + group_id
                 xyf_si = np.argsort(xyf_i)
                 xyf_i = xyf_i[xyf_si]
-                _, xyf_ui = np.unique(xyf_i, return_index=True)
+                xyf_ui = idl_argunique(xyf_i)
                 n_xyf_bin = xyf_ui.size
 
                 # There might be a better selection criteria to determine which

--- a/tests/test_gridding/test_visibility_degrid.py
+++ b/tests/test_gridding/test_visibility_degrid.py
@@ -170,7 +170,7 @@ def test_vis_degrid_zenith_2013(
     rel_diff = np.zeros_like(abs_diff)
     rel_diff[mean_nonzero] = abs_diff[mean_nonzero] / mean_abs[mean_nonzero]
 
-    assert np.abs(diff.mean()) < 0.03
-    assert abs_diff.max() < 4.5
+    assert np.abs(diff.mean()) < 0.003
+    assert abs_diff.max() < 0.5
     assert rel_diff[mean_nonzero].mean() < 0.1
     assert rel_diff.max() < 2


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The underlying issue was that numpy and idl unique index identification is different: numpy identifies the first occurrence and idl identifies the last occurrence. There was an assumption baked into a histogram call based on this that caused the error. This had been identified and handled properly in gridding but I missed it in degridding, partly because this only comes up under particular circumstances.

I found this while testing the mapping function. The test that breaks due to this will be introduced in the mapping function, but this fix did allow me to tighten some tolerances in existing tests. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of Changes
- [x] Bug Fixes
- [ ] New Feature(s) or Translations
- [ ] New tests
- [ ] Breaking Changes
- [ ] Refactoring/Internal restructuring
- [ ] Documentation
- [ ] Version Change
- [ ] Build or CI Change
- [ ] Other

## Checklist
<!--- Please remove any checklists that don't apply to your change type(s)-->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
**Bug Fixes**
- [ ] I have linked all issues associated with the bugs above.
- [x] I have added new tests or adjusted existing tests to cover bug (check the
Existing Tests Checklist above)
- [x] I have updated the [Changelog](https://pyfhd.readthedocs.io/en/latest/changelog/changelog.html)
      with details on the bug fix in the unreleased section (should be at the top
      of the relevant section -- changes are in reverse chronological order).
