### PR TITLE
Fix an indexing bug in gridding

### DIFF
--- a/docs/source/changelog/changelog.md
+++ b/docs/source/changelog/changelog.md
@@ -38,6 +38,8 @@ the new `analytic-beam-yaml` option to configure them.
 * Added handling for `~` in paths in config yamls.
 
 ### Bug Fixes
+* Fixed a bug in gridding where the wrong frequency index (and possibly sometimes
+the wrong baseline index) was used.
 * Fixed a bug in degridding which lead to some visibilities not being calculated.
 * Fixed a couple of bugs in beam and psf setup where the FFT direction or
 normalization convention was wrong.

--- a/src/pyfhd/gridding/visibility_grid.py
+++ b/src/pyfhd/gridding/visibility_grid.py
@@ -179,7 +179,6 @@ def visibility_grid(
     n_freq_use = frequency_array.size
     psf_dim2 = 2 * psf_dim
     psf_dim3 = psf_dim**2
-    bi_use_reduced = bi_use % n_baselines
 
     # Flags have been defined in the function definition
     # Instead of reading the flags and then setting them.
@@ -273,12 +272,12 @@ def visibility_grid(
         ymin_use = ymin.flat[ind0]
 
         # Find the frequency group per index
-        freq_i = inds % n_freq_use
+        freq_i, bt_index = np.unravel_index(inds, (n_freq_use, n_baselines * n_samples))
+        _, baseline_inds = np.unravel_index(bt_index, (n_samples, n_baselines))
         fbin = freq_bin_i[freq_i]
 
         # Calculate the number of selected visibilities and their baseline index
         vis_n = bin_n[bin_i[bi]]
-        baseline_inds = bi_use_reduced[((inds / n_f_use) % n_baselines).astype(int)]
 
         if interp_flag:
             # Calculate the interpolated kernel on the uv-grid given the
@@ -323,7 +322,7 @@ def visibility_grid(
 
             # Calculate a unique index for each kernel location and kernel type
             # in order to reduce operations if there are repeats
-            group_id = group_arr.flat[inds]
+            group_id = group_arr[freq_i, baseline_inds]
             group_max = np.max(group_id) + 1
             xyf_i = (
                 x_off + y_off * psf_resolution + fbin * psf_resolution**2

--- a/tests/test_gridding/test_visibility_grid.py
+++ b/tests/test_gridding/test_visibility_grid.py
@@ -264,21 +264,21 @@ def test_visibility_grid(
     )
     # All atols are done by the lowest precision that passed for ALL tests
     npt.assert_allclose(gridding_dict["image_uv"], h5_after["image_uv"], atol=1.5e-7)
-    npt.assert_allclose(gridding_dict["weights"], h5_after["weights"], atol=1e-8)
-    npt.assert_allclose(gridding_dict["variance"], h5_after["variance"], atol=1e-8)
+    npt.assert_allclose(gridding_dict["weights"], h5_after["weights"], atol=1.5e-9)
+    npt.assert_allclose(gridding_dict["variance"], h5_after["variance"], atol=2.5e-13)
     # Differences in baseline grids locations from precision errors in the
     # offsets caused differences in the histogram bin_n
     # The minor difference in bin_n affected the uniform filter. The precision
     # difference could cause errors up to 1
     # This doesn't occur for every test.
-    npt.assert_allclose(gridding_dict["obs"]["nf_vis"], h5_after["nf_vis"], atol=1e-8)
+    npt.assert_allclose(gridding_dict["obs"]["nf_vis"], h5_after["nf_vis"])
     npt.assert_allclose(
         gridding_dict["uniform_filter"], h5_after["uniform_filter"], atol=0.5
     )
 
     if "model_return" in gridding_dict:
         npt.assert_allclose(
-            gridding_dict["model_return"], h5_after["model_return"], atol=1e-7
+            gridding_dict["model_return"], h5_after["model_return"], atol=4.1e-8
         )
 
 
@@ -445,18 +445,10 @@ def test_full_visibility_grid(full_before_gridding: Path, full_after_gridding: P
         bi_use=h5_before["bi_use"],
     )
     # All atols are done by the lowest precision that passed for ALL tests
-    npt.assert_allclose(gridding_dict["image_uv"], h5_after["image_uv"], atol=1e-8)
-    npt.assert_allclose(gridding_dict["weights"], h5_after["weights"], atol=1e-8)
-    npt.assert_allclose(gridding_dict["variance"], h5_after["variance"], atol=1e-8)
-    npt.assert_allclose(gridding_dict["obs"]["nf_vis"], h5_after["nf_vis"], atol=1e-8)
-    # npt.assert_allclose(
-    #   gridding_dict['uniform_filter'], h5_after['uniform_filter'], atol = 1e-8
-    # )
-
-    if "model_return" in gridding_dict:
-        npt.assert_allclose(
-            gridding_dict["model_return"], h5_after["model_return"], atol=1e-8
-        )
+    npt.assert_allclose(gridding_dict["image_uv"], h5_after["image_uv"], atol=2e-11)
+    npt.assert_allclose(gridding_dict["weights"], h5_after["weights"], atol=2e-13)
+    npt.assert_allclose(gridding_dict["variance"], h5_after["variance"])
+    npt.assert_allclose(gridding_dict["obs"]["nf_vis"], h5_after["nf_vis"])
 
 
 # VIS_MODEL_FREQ_SPLIT VISIBILITY GRID TESTS BELOW
@@ -697,15 +689,17 @@ def test_visibility_grid_in_vis_model_freq_split(
         bi_use=h5_before["bi_use"],
     )
     # All atols are done by the lowest precision that passed for ALL tests
-    npt.assert_allclose(gridding_dict["image_uv"], h5_after["dirty_uv"], atol=1.5e-7)
-    npt.assert_allclose(gridding_dict["weights"], h5_after["weights_holo"], atol=1e-8)
-    npt.assert_allclose(gridding_dict["variance"], h5_after["variance_holo"], atol=1e-8)
+    npt.assert_allclose(gridding_dict["image_uv"], h5_after["dirty_uv"], atol=2.1e-9)
+    npt.assert_allclose(gridding_dict["weights"], h5_after["weights_holo"], atol=4e-11)
     npt.assert_allclose(
-        gridding_dict["model_return"], h5_after["model_return"], atol=1e-8
+        gridding_dict["variance"], h5_after["variance_holo"], atol=1.1e-12
+    )
+    npt.assert_allclose(
+        gridding_dict["model_return"], h5_after["model_return"], atol=2.1e-9
     )
     # Differences in baseline grids locations from precision errors in the
     # offsets caused differences in the histogram bin_n
     # The minor difference in bin_n affected the uniform filter. The precision
     # difference could cause errors up to 1
     # This doesn't occur for every test.
-    npt.assert_allclose(gridding_dict["n_vis"], h5_after["n_vis"], atol=1e-8)
+    npt.assert_allclose(gridding_dict["n_vis"], h5_after["n_vis"])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This was yet another indexing bug caused by copying over FHD indexing math which is incorrect for python. This lead to incorrect frequency indices and possibly incorrect baseline indices in some cases.

I found this while testing the mapping function. The test that breaks due to this will be introduced in the mapping function, but this fix did allow me to tighten some tolerances in existing tests.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged. -->

## Types of Changes
- [x] Bug Fixes
- [ ] New Feature(s) or Translations
- [ ] New tests
- [ ] Breaking Changes
- [ ] Refactoring/Internal restructuring
- [ ] Documentation
- [ ] Version Change
- [ ] Build or CI Change
- [ ] Other

## Checklist
<!--- Please remove any checklists that don't apply to your change type(s)-->
<!--- Go over all the following points, and replace the space with an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
**Bug Fixes**
- [ ] I have linked all issues associated with the bugs above.
- [x] I have added new tests or adjusted existing tests to cover bug (check the
Existing Tests Checklist above)
- [x] I have updated the [Changelog](https://pyfhd.readthedocs.io/en/latest/changelog/changelog.html)
      with details on the bug fix in the unreleased section (should be at the top
      of the relevant section -- changes are in reverse chronological order).